### PR TITLE
Support raw snapshots

### DIFF
--- a/sbin/update-snapshot-pointers.sh
+++ b/sbin/update-snapshot-pointers.sh
@@ -17,7 +17,7 @@ function prompt_to_update_link {
     link_name="$1"
     link_name_title_case="$(echo "$link_name" | sed 's/.*/\L&/; s/[a-z]*/\u&/g')"
     new_snapshot="$2"
-    new_target="/${new_snapshot//@//.zfs/snapshot/}/www"
+    new_target="/${new_snapshot//@//.zfs/snapshot/}"
     old_target="$(readlink "/data/pointers/$link_name")"
 
     if [[ "$new_target" != "$old_target" ]]; then

--- a/www/HEADER.php
+++ b/www/HEADER.php
@@ -54,15 +54,17 @@ $URI = $_SERVER['REQUEST_URI'];
         <ul class="nav nav-tabs nav-justified">
 <?php
 
-    if (strpos($URI, '/snapshot/') === 0) {
+    if (strpos($URI, '/snapshot/') === 0 || strpos($URI, '/raw/snapshot/') === 0) {
+        $array_uri = explode('/', $URI);
+        $uri_snapshot_pos = array_search('snapshot', $array_uri) + 1;
         foreach (['previous', 'current', 'next'] as $p) {
             $c = '';
-            if (strpos($URI, "/snapshot/$p/") === 0) {
+            if (strpos($URI, "/snapshot/$p/") !== false) {
                 $c = 'active';
             };
             $s = explode('/', readlink('/data/pointers/'.$p))[5];
-            $ua = explode('/', $URI);
-            $ua[2] = $p;
+            $ua = $array_uri;
+            $ua[$uri_snapshot_pos] = $p;
             $ut = implode('/', $ua);
             echo "        <li role=\"presentation\" class=\"$c\"><a href=\"$ut\" title=\"$s\"><b>$p</b><br>$s</a></li>\n";
         };


### PR DESCRIPTION
Rather than the `www` subdirectory.
This allows the raw source to be exposed which has proven to be useful for repositories with complex metadata.